### PR TITLE
fix(frontend): row deletion, sidebar groups, totals, and modal polish

### DIFF
--- a/backend/domain/invoices/entity.py
+++ b/backend/domain/invoices/entity.py
@@ -28,4 +28,7 @@ class Invoice(InvoiceBase, table=True):
         default_factory=lambda: datetime.now(timezone.utc))
 
     group: "Group" = Relationship(back_populates="invoices")
-    extractions: List["InvoiceExtraction"] = Relationship(back_populates="invoice")
+    extractions: List["InvoiceExtraction"] = Relationship(
+        back_populates="invoice",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useStore } from "@/lib/store";
 import { groupsApi } from "@/lib/api";
@@ -176,6 +176,7 @@ export default function DashboardPage() {
                 onMenuToggle={() =>
                   setMenuOpen(menuOpen === group.id ? null : group.id)
                 }
+                onMenuClose={() => setMenuOpen(null)}
                 onDelete={() => {
                   setMenuOpen(null);
                   setConfirmDeleteId(group.id);
@@ -246,6 +247,7 @@ function GroupCard({
   menuOpen,
   onOpen,
   onMenuToggle,
+  onMenuClose,
   onDelete,
   style,
 }: {
@@ -253,11 +255,24 @@ function GroupCard({
   menuOpen: boolean;
   onOpen: () => void;
   onMenuToggle: () => void;
+  onMenuClose: () => void;
   onDelete: () => void;
   style?: React.CSSProperties;
 }) {
   const visibleCols = group.columns?.slice(0, 3) ?? [];
   const extraCount = (group.columns?.length ?? 0) - visibleCols.length;
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handle = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onMenuClose();
+      }
+    };
+    document.addEventListener("mousedown", handle);
+    return () => document.removeEventListener("mousedown", handle);
+  }, [menuOpen, onMenuClose]);
 
   return (
     <div
@@ -269,7 +284,7 @@ function GroupCard({
         <div className="w-10 h-10 bg-emerald-50 rounded-xl flex items-center justify-center text-emerald-600">
           <Icon name="folder" size={20} stroke={1.75} />
         </div>
-        <div className="relative" onClick={(e) => e.stopPropagation()}>
+        <div className="relative" ref={menuRef} onClick={(e) => e.stopPropagation()}>
           <button
             onClick={onMenuToggle}
             className="w-7 h-7 flex items-center justify-center rounded-lg text-emerald-600 bg-emerald-50 hover:bg-emerald-100 transition-colors"

--- a/frontend/src/app/groups/[id]/page.tsx
+++ b/frontend/src/app/groups/[id]/page.tsx
@@ -236,6 +236,35 @@ export default function GroupPage() {
   );
 }
 
+function parseNumber(v: unknown): number | null {
+  if (v === null || v === undefined || v === "") return null;
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  if (typeof v !== "string") return null;
+  // Strip currency symbols, thousands separators, and surrounding whitespace.
+  // Accepts "Rp 12.500", "$1,234.56", "12.500,50" (treated as European), etc.
+  const cleaned = v.replace(/[^\d,.\-]/g, "").trim();
+  if (!cleaned) return null;
+  let normalized = cleaned;
+  const lastComma = cleaned.lastIndexOf(",");
+  const lastDot = cleaned.lastIndexOf(".");
+  if (lastComma > lastDot) {
+    // European-style: "12.500,50" -> "12500.50"
+    normalized = cleaned.replace(/\./g, "").replace(",", ".");
+  } else {
+    // US-style: "1,234.56" -> "1234.56"
+    normalized = cleaned.replace(/,/g, "");
+  }
+  const n = Number(normalized);
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatTotal(n: number): string {
+  return n.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+}
+
 function InvoicesTable({
   columns,
   invoices,
@@ -254,6 +283,23 @@ function InvoicesTable({
       </div>
     );
   }
+
+  // Only sum the "Price" column (case-insensitive). Non-numeric values are
+  // skipped, not treated as zero.
+  const priceColumn = columns.find((c) => c.trim().toLowerCase() === "price");
+  let priceSum = 0;
+  let priceCount = 0;
+  if (priceColumn) {
+    for (const inv of invoices) {
+      const data = (inv.data ?? {}) as Record<string, unknown>;
+      const n = parseNumber(data[priceColumn]);
+      if (n !== null) {
+        priceSum += n;
+        priceCount += 1;
+      }
+    }
+  }
+  const showTotal = priceColumn && priceCount > 0;
 
   return (
     <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden shadow-sm">
@@ -339,6 +385,29 @@ function InvoicesTable({
               })
             )}
           </tbody>
+          {showTotal && invoices.length > 0 && (
+            <tfoot>
+              <tr className="border-t-2 border-slate-200 bg-slate-50">
+                {columns.map((col) => (
+                  <td
+                    key={col}
+                    className="px-4 py-3 text-[13px] font-semibold text-slate-700 whitespace-nowrap"
+                  >
+                    {col === priceColumn && (
+                      <span>
+                        <span className="text-[11px] uppercase tracking-wider font-bold text-slate-400 mr-2">
+                          Total
+                        </span>
+                        {formatTotal(priceSum)}
+                      </span>
+                    )}
+                  </td>
+                ))}
+                <td />
+                <td />
+              </tr>
+            </tfoot>
+          )}
         </table>
       </div>
       <div className="px-4 py-2.5 bg-slate-50 border-t border-slate-100 text-[11px] text-slate-400">

--- a/frontend/src/app/upload/[id]/page.tsx
+++ b/frontend/src/app/upload/[id]/page.tsx
@@ -40,6 +40,7 @@ export default function UploadPage() {
   const [loadingMeta, setLoadingMeta] = useState(true);
   const [metaError, setMetaError] = useState<string | null>(null);
   const [confirmLoading, setConfirmLoading] = useState(false);
+  const [uploadingAnother, setUploadingAnother] = useState(false);
 
   useEffect(() => {
     if (!user) {
@@ -91,13 +92,25 @@ export default function UploadPage() {
     setUploadError(null);
     try {
       await receiptApi.insertToSheet(id, jobId, items);
-      // Persist the first extracted item into the invoice's `data` field
-      // so the group page can show it as a row.
-      const first = items[0];
+      // Each preview row becomes its own invoice (= one row in the group page).
+      // The original invoice (created when the user opened the upload page)
+      // gets the first item; remaining items become new invoices in the same
+      // group so manually-added rows actually show up.
+      const [first, ...rest] = items;
       if (first) {
         await invoicesApi.update(id, {
           data: first as Record<string, unknown>,
         });
+      }
+      if (rest.length > 0 && groupId !== null) {
+        await Promise.all(
+          rest.map((item) =>
+            invoicesApi.create({
+              groupId,
+              data: item as Record<string, unknown>,
+            }),
+          ),
+        );
       }
       setUploadPhase("done");
     } catch (e) {
@@ -111,6 +124,21 @@ export default function UploadPage() {
   const goBackToGroup = () => {
     if (groupId !== null) router.push(`/groups/${groupId}`);
     else router.push("/dashboard");
+  };
+
+  const handleUploadAnother = async () => {
+    if (groupId === null) return;
+    setUploadingAnother(true);
+    setUploadError(null);
+    try {
+      const invoice = await invoicesApi.create({ groupId, data: {} });
+      resetUpload();
+      router.push(`/upload/${invoice.id}`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to start a new upload.";
+      setUploadError(msg);
+      setUploadingAnother(false);
+    }
   };
 
   // ── Done screen ───────────────────────────────────────────────────────────
@@ -145,11 +173,18 @@ export default function UploadPage() {
                 Back to Group <Icon name="arrowRight" size={15} />
               </button>
               <button
-                onClick={resetUpload}
-                className="px-6 py-3 border border-slate-200 text-slate-600 rounded-xl text-[13px] font-medium hover:bg-slate-50 transition-colors"
+                onClick={handleUploadAnother}
+                disabled={uploadingAnother || groupId === null}
+                className="flex items-center justify-center gap-2 px-6 py-3 border border-slate-200 text-slate-600 rounded-xl text-[13px] font-medium hover:bg-slate-50 transition-colors disabled:opacity-50"
               >
+                {uploadingAnother && (
+                  <div className="w-4 h-4 border-2 border-slate-300 border-t-slate-600 rounded-full animate-spin" />
+                )}
                 Upload Another Receipt
               </button>
+              {uploadError && (
+                <p className="text-[12px] text-red-600 mt-1">{uploadError}</p>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,16 +1,35 @@
 "use client";
 
+import { useEffect } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import { useStore } from "@/lib/store";
+import { groupsApi } from "@/lib/api";
 import Icon from "@/components/ui/Icon";
 import { cn } from "@/lib/utils";
 
 export default function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
+  const { user, groups, setGroups } = useStore();
+
+  useEffect(() => {
+    if (!user) return;
+    groupsApi
+      .list()
+      .then(setGroups)
+      .catch(() => {
+        // Fail silently — the dashboard surfaces load errors more visibly.
+      });
+  }, [user, setGroups]);
+
+  const activeGroupId = (() => {
+    const m = pathname?.match(/^\/groups\/(\d+)/);
+    return m ? Number(m[1]) : null;
+  })();
 
   return (
     <aside className="w-[220px] bg-white border-r border-slate-200 flex-shrink-0 overflow-y-auto flex flex-col">
-      <nav className="p-3">
+      <nav className="p-3 flex-1 flex flex-col gap-4">
         <button
           onClick={() => router.push("/dashboard")}
           className={cn(
@@ -23,6 +42,33 @@ export default function Sidebar() {
           <Icon name="grid" size={14} />
           Dashboard
         </button>
+
+        {groups.length > 0 && (
+          <div className="flex flex-col gap-1">
+            <div className="px-3 text-[10px] font-bold uppercase tracking-wider text-slate-400">
+              Groups
+            </div>
+            {groups.map((g) => {
+              const isActive = activeGroupId === g.id;
+              return (
+                <button
+                  key={g.id}
+                  onClick={() => router.push(`/groups/${g.id}`)}
+                  className={cn(
+                    "w-full flex items-center gap-2 px-3 py-2 rounded-lg text-[13px] font-medium transition-colors text-left",
+                    isActive
+                      ? "bg-emerald-50 text-emerald-700"
+                      : "text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+                  )}
+                  title={g.name}
+                >
+                  <Icon name="folder" size={14} />
+                  <span className="truncate">{g.name}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
       </nav>
     </aside>
   );

--- a/frontend/src/components/modals/CreateGroupModal.tsx
+++ b/frontend/src/components/modals/CreateGroupModal.tsx
@@ -99,7 +99,7 @@ export default function CreateGroupModal({ open, onClose }: Props) {
             <label className="block text-[12px] font-semibold text-slate-600 mb-2">
               Columns
             </label>
-            <div className="space-y-2 max-h-52 overflow-y-auto pr-1">
+            <div className="space-y-2 max-h-52 overflow-y-auto px-1 -mx-1 py-2">
               {columns.map((col, i) => (
                 <div key={i} className="flex items-center gap-2">
                   <span className="text-[11px] text-slate-400 w-5 flex-shrink-0 text-right">
@@ -132,7 +132,7 @@ export default function CreateGroupModal({ open, onClose }: Props) {
                 Prices
               </div>
               <span className="text-[10px] text-slate-400 bg-slate-100 px-2 py-1 rounded-lg flex-shrink-0">
-                Automatically
+                Automatic
               </span>
             </div>
 

--- a/frontend/src/components/upload/ReceiptPreview.tsx
+++ b/frontend/src/components/upload/ReceiptPreview.tsx
@@ -15,6 +15,9 @@ interface Props {
 
 export default function ReceiptPreview({ items: initial, columns, confidence, onConfirm, loading }: Props) {
   const [items, setItems] = useState<ExtractedItem[]>(initial);
+  // Rows present at mount are AI-extracted and cannot be deleted; rows added
+  // via the "Add row" button are user-added and can be removed.
+  const [userAdded, setUserAdded] = useState<boolean[]>(() => initial.map(() => false));
   const [editCell, setEditCell] = useState<string | null>(null);
   const [editVal, setEditVal] = useState("");
 
@@ -26,7 +29,15 @@ export default function ReceiptPreview({ items: initial, columns, confidence, on
     setItems(items.map((row, i) => i === ri ? { ...row, [colId]: editVal } : row));
     setEditCell(null);
   };
-  const addRow = () => setItems([...items, Object.fromEntries(columns.map((c) => [c.id, ""]))]);
+  const addRow = () => {
+    setItems([...items, Object.fromEntries(columns.map((c) => [c.id, ""]))]);
+    setUserAdded([...userAdded, true]);
+  };
+  const deleteRow = (ri: number) => {
+    setItems(items.filter((_, i) => i !== ri));
+    setUserAdded(userAdded.filter((_, i) => i !== ri));
+    if (editCell?.startsWith(`${ri}:`)) setEditCell(null);
+  };
 
   const pct = Math.round(confidence * 100);
   const isHigh = pct >= 80;
@@ -51,11 +62,12 @@ export default function ReceiptPreview({ items: initial, columns, confidence, on
                     {col.name}
                   </th>
                 ))}
+                <th className="w-10" />
               </tr>
             </thead>
             <tbody>
               {items.map((row, ri) => (
-                <tr key={ri} className="border-b border-slate-100 last:border-0 hover:bg-slate-50/60 transition-colors">
+                <tr key={ri} className="border-b border-slate-100 last:border-0 hover:bg-slate-50/60 transition-colors group">
                   {columns.map((col) => {
                     const key = `${ri}:${col.id}`;
                     const isEditing = editCell === key;
@@ -73,6 +85,17 @@ export default function ReceiptPreview({ items: initial, columns, confidence, on
                       </td>
                     );
                   })}
+                  <td className="w-10 px-2 py-2.5 text-right">
+                    {userAdded[ri] && (
+                      <button
+                        onClick={(e) => { e.stopPropagation(); deleteRow(ri); }}
+                        className="opacity-0 group-hover:opacity-100 transition-opacity w-7 h-7 flex items-center justify-center rounded-lg text-slate-400 hover:bg-red-50 hover:text-red-500"
+                        title="Delete row"
+                      >
+                        <Icon name="trash" size={13} />
+                      </button>
+                    )}
+                  </td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
fix(frontend): row deletion, sidebar groups, totals, and modal polish

- ReceiptPreview: allow deleting user-added rows (AI-extracted rows remain locked) by tracking row origin in a parallel boolean array
- Upload page: "Upload Another Receipt" now creates a new invoice and routes to it, and confirm persists every preview row by creating an extra invoice per item beyond the first so manually-added rows show up in the group
- Group page: add a footer row that sums the "Price" column only, with currency- and locale-tolerant number parsing
- Sidebar: list user's groups as clickable nav items; highlight the active group and fetch on mount
- Dashboard: close the three-dot menu when clicking outside via a document mousedown listener
- CreateGroupModal: stop clipping the column input focus ring inside the scroll container (px-1 -mx-1 py-2)
- Backend (invoices): cascade-delete InvoiceExtraction rows with their parent Invoice so deleting a Group no longer fails with a NOT NULL violation on invoice_extractions.invoice_id